### PR TITLE
Fixed #47

### DIFF
--- a/harbour-storeman/qml/pages/AuthorisationDialog.qml
+++ b/harbour-storeman/qml/pages/AuthorisationDialog.qml
@@ -60,7 +60,7 @@ Dialog {
                 id: usernameField
                 width: parent.width
                 //: A translated string should not be longer than the original
-                //% "Username or e-mail address"
+                //% "Username"
                 placeholderText: qsTrId("orn-username")
                 label: placeholderText
                 validator: RegExpValidator {

--- a/harbour-storeman/translations/harbour-storeman-de_DE.ts
+++ b/harbour-storeman/translations/harbour-storeman-de_DE.ts
@@ -426,7 +426,7 @@
     <message id="orn-username">
         <source>Username or e-mail address</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Benutzername oder E-Mail-Adresse</translation>
+        <translation>Benutzername</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not store your password or send it to third-parties.</source>

--- a/harbour-storeman/translations/harbour-storeman-hu_HU.ts
+++ b/harbour-storeman/translations/harbour-storeman-hu_HU.ts
@@ -424,7 +424,7 @@
     <message id="orn-username">
         <source>Username or e-mail address</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Felhasználónév vagy e-mail cím</translation>
+        <translation>Felhasználónév</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not store your password or send it to third-parties.</source>


### PR DESCRIPTION
Change the translation hint to show only the username (as email is not accepted).

It might be useful to notify the translators to update their labels as well.