### PR TITLE
Suggestion to streamline README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ Read [here](harbour-storeman/translations/README.md)
 
 ## Installing Storeman
 
-A changelog, screenshots and installable RPMs are available at [OpenRepos.net](https://github.com/mentaljam/harbour-storeman/edit/master/README.md).
+Sreenshots and installable RPMs are available at [OpenRepos.net](https://openrepos.net/content/osetr/storeman).

--- a/README.md
+++ b/README.md
@@ -2,18 +2,6 @@
 
 Unofficial native OpenRepos.net client for Sailfish OS
 
-[![Release](https://img.shields.io/github/release/mentaljam/harbour-storeman.svg)]()
-
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-01.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-01.png)
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-02.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-02.png)
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-03.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-03.png)
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-04.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-04.png)
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-05.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-05.png)
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-06.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-06.png)
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-07.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-07.png)
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-08.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-08.png)
-[![](https://openrepos.net/sites/default/files/styles/medium/public/packages/6416/screenshot-screenshot-storeman-09.png)](https://openrepos.net/sites/default/files/packages/6416/screenshot-screenshot-storeman-09.png)
-
 ## Current features
 
 ### Working with OpenRepos
@@ -46,3 +34,7 @@ Unofficial native OpenRepos.net client for Sailfish OS
 ## Translations
 
 Read [here](harbour-storeman/translations/README.md)
+
+## Installing Storeman
+
+A changelog, screenshots and installable RPMs are available at [OpenRepos.net](https://github.com/mentaljam/harbour-storeman/edit/master/README.md).


### PR DESCRIPTION
All links in the first section did not work (tested on Firefox / Fennec 62 and Jolla browser):
- Graphical release tag image displayed "release v0.0.29-1".
- Link of the release tag image results in a "404 - not found".
- None of the screenshots was displayed.

As the screenshots are also available [at OpenRepos](https://openrepos.net/content/osetr/storeman) and the release tag image seems to require regular, manual maintenance, I suggest (per this PR) to delete them altogether.

Also adding a web-link to Storeman at OpenRepos with a little text., to guide users who found this developer page to an installable RPM of Storeman.
 
HTH

P.S.: Screenshot to illustrate README.md before this change:
![screenshot_20181122_003](https://user-images.githubusercontent.com/16547876/48924273-9a995a00-eeb6-11e8-8d5e-c5886172437e.png)

