### PR TITLE
Fix std:bind not being defined.

### DIFF
--- a/src/ornclient.cpp
+++ b/src/ornclient.cpp
@@ -2,6 +2,7 @@
 #include "ornclient_p.h"
 #include "ornutils.h"
 
+#include <functional>
 #include <QSettings>
 #include <QTimer>
 #include <QNetworkAccessManager>


### PR DESCRIPTION
The app builds file in the SDK but not on obs.
According to docs std:bind needs <functional>.