### PR TITLE
Use Silica-provided size formatter

### DIFF
--- a/qml/components/AppInformation.qml
+++ b/qml/components/AppInformation.qml
@@ -4,38 +4,6 @@ import harbour.orn 1.0
 
 BackgroundItem {
     property bool _expanded: false
-    readonly property var _sizeTmpls: [
-        //% "%0 KB"
-        QT_TRID_NOOP("orn-size-kb"),
-        //% "%0 MB"
-        QT_TRID_NOOP("orn-size-mb"),
-        //% "%0 GB"
-        QT_TRID_NOOP("orn-size-gb")
-    ]
-
-    function prettySize(size) {
-
-        // Undefined
-        if (!size) {
-            return ""
-        }
-
-        // Bytes
-        var s = size
-        if (s < 1024) {
-            //% "%n byte(s)"
-            return qsTrId("orn-size-bytes", s).arg(Number(s).toLocaleString(_locale))
-        }
-
-        // KB, MB, GB
-        var i = -1
-        while (i < 3 && s >= 1024) {
-            s /= 1024
-            ++i
-        }
-
-        return qsTrId(_sizeTmpls[i]).arg(Number(s).toLocaleString(_locale, 'f', 1))
-    }
 
     id: infoItem
     width: parent.width
@@ -111,7 +79,7 @@ BackgroundItem {
             //% "Installed size"
             label: qsTrId("orn-size-installed")
             visible: installedVersion.visible
-            value: prettySize(app.installedVersionSize)
+            value: Format.formatFileSize(app.installedVersionSize)
         }
 
         AppInfoLabel {
@@ -136,8 +104,8 @@ BackgroundItem {
             //% "Download / install size"
             label: qsTrId("orn-size-download-install")
             visible: _expanded && app.availableVersionIsNewer
-            value: prettySize(app.availableVersionDownloadSize) + " / " +
-                   prettySize(app.availableVersionInstallSize)
+            value: Format.formatFileSize(app.availableVersionDownloadSize) + " / " +
+                   Format.formatFileSize(app.availableVersionInstallSize)
         }
 
         AppInfoLabel {
@@ -160,8 +128,8 @@ BackgroundItem {
         AppInfoLabel {
             label: qsTrId("orn-size-download-install")
             visible: globalVersion.visible
-            value: prettySize(app.globalVersionDownloadSize) + " / " +
-                   prettySize(app.globalVersionInstallSize)
+            value: Format.formatFileSize(app.globalVersionDownloadSize) + " / " +
+                   Format.formatFileSize(app.globalVersionInstallSize)
         }
 
         Image {

--- a/translations/harbour-storeman-cs.ts
+++ b/translations/harbour-storeman-cs.ts
@@ -762,18 +762,6 @@
         <source>Available version</source>
         <translation>Dostupná verze</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Nelze najít balíček</translation>
@@ -781,14 +769,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Velikost instalace</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>1 bajt</numerusform>
-            <numerusform>%n bajtů</numerusform>
-            <numerusform>%n bajtů</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-da.ts
+++ b/translations/harbour-storeman-da.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Tilgængelig version</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation type="unfinished"></translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-de_DE.ts
+++ b/translations/harbour-storeman-de_DE.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Verfügbare Version</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Paket nicht gefunden</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Installationsgröße</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n bytes</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-el.ts
+++ b/translations/harbour-storeman-el.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Διαθέσιμη έκδοση</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Αδύνατη η εύρεση του πακέτου</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Εγκατεστημένο μέγεθος</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n byte</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-es.ts
+++ b/translations/harbour-storeman-es.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Versión disponible</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>No se encontró el paquete</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Tamaño instalado</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n bytes</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-fi_FI.ts
+++ b/translations/harbour-storeman-fi_FI.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Saatavilla oleva versio</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 Kt</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 Mt</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 Gt</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Pakettia ei löytynyt</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Asennuskoko</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n tavu</numerusform>
-            <numerusform>%n tavua</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-fr.ts
+++ b/translations/harbour-storeman-fr.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Version disponible</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 Ko</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 Mo</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 Go</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Paquet introuvable</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Taille installée</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n octet</numerusform>
-            <numerusform>%n octets</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-hu_HU.ts
+++ b/translations/harbour-storeman-hu_HU.ts
@@ -756,18 +756,6 @@
         <source>Available version</source>
         <translation>Elérhető verzió</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>A csomag nem található</translation>
@@ -775,12 +763,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Telepített méret</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-it.ts
+++ b/translations/harbour-storeman-it.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Versione disponibile</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Impossibie trovare il pacchetto</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Dimensione installato</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n byte</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-nl.ts
+++ b/translations/harbour-storeman-nl.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Beschikbaar</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Kon pakket niet vinden</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Geïnstalleerde grootte</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n bytes</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-nl_BE.ts
+++ b/translations/harbour-storeman-nl_BE.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Beschikbaar</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Kon pakket niet vinden</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Geïnstalleerde grootte</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n bytes</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-no.ts
+++ b/translations/harbour-storeman-no.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Tilgjengengelig versjon</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Finner ikke pakke</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Installasjonens størrelse</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-pl.ts
+++ b/translations/harbour-storeman-pl.ts
@@ -762,18 +762,6 @@
         <source>Available version</source>
         <translation>Dostępna wersja</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Nie udało się odnaleźć pakietu</translation>
@@ -781,14 +769,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Rozmiar zainstalowanej aplikacji</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n bajt</numerusform>
-            <numerusform>%n bajty</numerusform>
-            <numerusform>%n bajtów</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-pt_BR.ts
+++ b/translations/harbour-storeman-pt_BR.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Versão disponível</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Não foi possível encontrar pacote</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Tamanho instalado</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n bytes</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-ru.ts
+++ b/translations/harbour-storeman-ru.ts
@@ -764,18 +764,6 @@ Storeman не передает ваш пароль третьим лицам.</t
         <source>Available version</source>
         <translation>Доступная версия</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 КБ</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 МБ</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 ГБ</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Пакет не найден</translation>
@@ -783,14 +771,6 @@ Storeman не передает ваш пароль третьим лицам.</t
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Установленный размер</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n байт</numerusform>
-            <numerusform>%n байта</numerusform>
-            <numerusform>%n байтов</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-sl_SI.ts
+++ b/translations/harbour-storeman-sl_SI.ts
@@ -765,18 +765,6 @@
         <source>Available version</source>
         <translation>Razpoložljive različice</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Ne najdem paketa</translation>
@@ -784,15 +772,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Nameščena velikost</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n bajt</numerusform>
-            <numerusform>%n bajta</numerusform>
-            <numerusform>%n bajte</numerusform>
-            <numerusform>%n bajtov</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-sv.ts
+++ b/translations/harbour-storeman-sv.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Tillgänglig version</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Kunde inte hitta paket</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Installerad storlek</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n byte</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman-zh_CN.ts
+++ b/translations/harbour-storeman-zh_CN.ts
@@ -756,18 +756,6 @@
         <source>Available version</source>
         <translation>可用版本</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>不能找到应用包</translation>
@@ -775,12 +763,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>安装后大小</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n bytes</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>

--- a/translations/harbour-storeman.ts
+++ b/translations/harbour-storeman.ts
@@ -759,18 +759,6 @@
         <source>Available version</source>
         <translation>Available version</translation>
     </message>
-    <message id="orn-size-kb">
-        <source>%0 KB</source>
-        <translation>%0 KB</translation>
-    </message>
-    <message id="orn-size-mb">
-        <source>%0 MB</source>
-        <translation>%0 MB</translation>
-    </message>
-    <message id="orn-size-gb">
-        <source>%0 GB</source>
-        <translation>%0 GB</translation>
-    </message>
     <message id="orn-error-packagenotfound">
         <source>Couldn&apos;t find package</source>
         <translation>Couldn&apos;t find package</translation>
@@ -778,13 +766,6 @@
     <message id="orn-size-installed">
         <source>Installed size</source>
         <translation>Installed size</translation>
-    </message>
-    <message id="orn-size-bytes" numerus="yes">
-        <source>%n byte(s)</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n bytes</numerusform>
-        </translation>
     </message>
     <message id="orn-size-download-install">
         <source>Download / install size</source>


### PR DESCRIPTION
Silica provides formatter for a really long time (since Sailfish 2.0, I suppose). It is undocumented but public (appears [sometimes](https://sailfishos.org/develop/docs/silica/qml-sailfishsilica-sailfish-silica-remorse.html/#3-clearing-data) in examples).

`Format.formatFileSize` automatically provides translations for all languages supported in Sailfish OS.