### PR TITLE
Set Requires: sailfish-version = 3.3

### DIFF
--- a/rpm/harbour-storeman.spec
+++ b/rpm/harbour-storeman.spec
@@ -1,7 +1,7 @@
 Name:           harbour-storeman
 Summary:        OpenRepos Client for Sailfish OS
 Version:        0.2.2
-Release:        1~sfos3.3
+Release:        2~sfos3.3
 Group:          Qt/Qt
 License:        MIT
 URL:            https://github.com/mentaljam/harbour-storeman

--- a/rpm/harbour-storeman.spec
+++ b/rpm/harbour-storeman.spec
@@ -7,7 +7,7 @@ License:        MIT
 URL:            https://github.com/mentaljam/harbour-storeman
 Source0:        %{name}-%{version}.tar.bz2
 
-Requires:       sailfish-version <= 3.3
+Requires:       sailfish-version = 3.3
 Requires:       sailfishsilica-qt5
 Requires:       nemo-qml-plugin-dbus-qt5
 Requires:       nemo-qml-plugin-notifications-qt5


### PR DESCRIPTION
... because with "<= 3.3" (in this, "SFOS 3.3" branch) it is offered as an update when the Storeman variant (branch) for SailfishOS 3.2 is installed (under SFOS 3.2, logically).

Screenshot taken with *harbour-storeman-0.2.2-1~sfos3.2.armv7hl.rpm* installed on an XperiaX@SFOS3.2.1.
Before taking this screenshot, all repositories were refreshed in Storeman and per `devel-su pkcon refresh`.
![Screenshot_20201006_001_edit](https://user-images.githubusercontent.com/16547876/95214861-9e0b0580-07f0-11eb-89a3-0657af2af6a1.png)