### PR TITLE
Overhaul Norwegian (Bokmål) translation

### DIFF
--- a/translations/harbour-storeman-nb.ts
+++ b/translations/harbour-storeman-nb.ts
@@ -1,0 +1,1082 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="no">
+<context>
+    <name></name>
+    <message id="orn-notrated">
+        <source>Not rated yet</source>
+        <translation>Ikke vurdert foreløpig</translation>
+    </message>
+    <message id="orn-repositories">
+        <source>Repositories</source>
+        <translation>Pakkebrønner</translation>
+    </message>
+    <message id="orn-refresh">
+        <source>Refresh</source>
+        <translation>Oppfrisk</translation>
+    </message>
+    <message id="orn-disable">
+        <source>Disable</source>
+        <translation>Deaktiver</translation>
+    </message>
+    <message id="orn-enable">
+        <source>Enable</source>
+        <translation>Aktiver</translation>
+    </message>
+    <message id="orn-enabled">
+        <source>Enabled</source>
+        <translation>Aktivert</translation>
+    </message>
+    <message id="orn-disabled">
+        <source>Disabled</source>
+        <translation>Deaktivert</translation>
+    </message>
+    <message id="orn-recently-updated">
+        <source>Recently updated</source>
+        <translation>Nylig oppdatert</translation>
+    </message>
+    <message id="orn-network-idle">
+        <source>Network is unavailable</source>
+        <translation>Nettverket er ikke tilgjengelig</translation>
+    </message>
+    <message id="orn-today">
+        <source>Today</source>
+        <translation>I dag</translation>
+    </message>
+    <message id="orn-yesterday">
+        <source>Yesterday</source>
+        <translation>I går</translation>
+    </message>
+    <message id="orn-this-week">
+        <source>This week</source>
+        <translation>Denne uken</translation>
+    </message>
+    <message id="orn-this-month">
+        <source>This month</source>
+        <translation>Denne måneden</translation>
+    </message>
+    <message id="orn-month-format">
+        <source>%0 %1</source>
+        <extracomment>Output format for the month and year - %0 is a long month name and %1 is a year (for example &quot;May 2017&quot;)</extracomment>
+        <translation>%0 %1</translation>
+    </message>
+    <message id="orn-adding-repo">
+        <source>Adding</source>
+        <translation>Legger til</translation>
+    </message>
+    <message id="orb-remove">
+        <source>Remove</source>
+        <translation>Fjern</translation>
+    </message>
+    <message id="orn-removing">
+        <source>Removing</source>
+        <translation>Fjerner</translation>
+    </message>
+    <message id="orn-error">
+        <source>An error occured</source>
+        <translation>En feil oppstod</translation>
+    </message>
+    <message id="orn-repo-add">
+        <source>Add repository</source>
+        <translation>Legg til pakkebrønn</translation>
+    </message>
+    <message id="orn-repo-enable">
+        <source>Enable repository</source>
+        <translation>Aktiver pakkebrønn</translation>
+    </message>
+    <message id="orn-install">
+        <source>Install</source>
+        <translation>Innstaller</translation>
+    </message>
+    <message id="orn-remove">
+        <source>Remove</source>
+        <translation>Fjern</translation>
+    </message>
+    <message id="orn-launch">
+        <source>Launch</source>
+        <translation>Kjør</translation>
+    </message>
+    <message id="orn-package-installed">
+        <source>Package %0 was successfully installed</source>
+        <translation>Pakken %0 ble installert</translation>
+    </message>
+    <message id="orn-package-removed">
+        <source>Package %0 was successfully removed</source>
+        <translation>Pakken %0 ble avinstallert</translation>
+    </message>
+    <message id="orn-installed">
+        <source>Installed</source>
+        <translation>Innstallert</translation>
+    </message>
+    <message id="orn-version-installed">
+        <source>Installed version</source>
+        <translation>Innstallert versjon</translation>
+    </message>
+    <message id="orn-version-updated">
+        <source>Last updated</source>
+        <translation>Sist oppdatert</translation>
+    </message>
+    <message id="orn-dt-format">
+        <source>yyyy-MM-dd hh:mm</source>
+        <extracomment>Output format for the date labels. For details visit http://doc.qt.io/qt-5/qdate.html#toString</extracomment>
+        <translation>yyyy-MM-dd hh:mm</translation>
+    </message>
+    <message id="orn-version-noavailable">
+        <source>No versions available</source>
+        <translation>Ingen tilgjengelig versjon</translation>
+    </message>
+    <message id="orn-comments">
+        <source>Comments</source>
+        <translation>Kommentarer</translation>
+    </message>
+    <message id="orn-author-apps">
+        <source>More by %0</source>
+        <translation>Mer av %0</translation>
+    </message>
+    <message id="orn-cat-coding-competition">
+        <source>Coding Competition</source>
+        <translation>Kodekonkurranse</translation>
+    </message>
+    <message id="orn-cat-applications">
+        <source>Applications</source>
+        <translation>Programmer</translation>
+    </message>
+    <message id="orn-cat-application">
+        <source>Application</source>
+        <translation>Program</translation>
+    </message>
+    <message id="orn-cat-ambience-themes">
+        <source>Ambience &amp; Themes</source>
+        <translation>Atmosfære og temaer</translation>
+    </message>
+    <message id="orn-cat-business">
+        <source>Business</source>
+        <translation>Kontor</translation>
+    </message>
+    <message id="orn-cat-city-guides-maps">
+        <source>City guides &amp; maps</source>
+        <translation>By- guide og kart</translation>
+    </message>
+    <message id="orn-cat-education-science">
+        <source>Education &amp; Science</source>
+        <translation>Utdanning og vitenskap</translation>
+    </message>
+    <message id="orn-cat-entertainment">
+        <source>Entertainment</source>
+        <translation>Underholdning</translation>
+    </message>
+    <message id="orn-cat-music">
+        <source>Music</source>
+        <translation>Musikk</translation>
+    </message>
+    <message id="orn-cat-network">
+        <source>Network</source>
+        <translation>Nettverk</translation>
+    </message>
+    <message id="orn-cat-news-info">
+        <source>News &amp; info</source>
+        <translation>Nyheter og opplysningstjenester</translation>
+    </message>
+    <message id="orn-cat-patches">
+        <source>Patches</source>
+        <translation>Patcher</translation>
+    </message>
+    <message id="orn-cat-photo-video">
+        <source>Photo &amp; video</source>
+        <translation>Foto og video</translation>
+    </message>
+    <message id="orn-cat-social-networks">
+        <source>Social Networks</source>
+        <translation>Sosiale nettverk</translation>
+    </message>
+    <message id="orn-cat-sports">
+        <source>Sports</source>
+        <translation>Sport</translation>
+    </message>
+    <message id="orn-cat-system">
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message id="orn-cat-unknown">
+        <source>Unknown</source>
+        <translation>Ukjent</translation>
+    </message>
+    <message id="orn-cat-utilities">
+        <source>Utilities</source>
+        <translation>Verketøy</translation>
+    </message>
+    <message id="orn-cat-games">
+        <source>Games</source>
+        <translation>Spill</translation>
+    </message>
+    <message id="orn-cat-game">
+        <source>Game</source>
+        <translation>Spill</translation>
+    </message>
+    <message id="orn-cat-action">
+        <source>Action</source>
+        <translation>Action</translation>
+    </message>
+    <message id="orn-cat-adventure">
+        <source>Adventure</source>
+        <translation>Eventyr</translation>
+    </message>
+    <message id="orn-cat-arcade">
+        <source>Arcade</source>
+        <translation>Arkade</translation>
+    </message>
+    <message id="orn-cat-card-casino">
+        <source>Card &amp; casino</source>
+        <translation>Kortspill og kasino</translation>
+    </message>
+    <message id="orn-cat-education">
+        <source>Education</source>
+        <translation>Utdanning</translation>
+    </message>
+    <message id="orn-cat-puzzle">
+        <source>Puzzle</source>
+        <translation>Pusslespill</translation>
+    </message>
+    <message id="orn-cat-strategy">
+        <source>Strategy</source>
+        <translation>Strategi</translation>
+    </message>
+    <message id="orn-cat-trivia">
+        <source>Trivia</source>
+        <translation>Kuriosa</translation>
+    </message>
+    <message id="orn-cat-translations">
+        <source>Translations</source>
+        <translation>Oversettelser</translation>
+    </message>
+    <message id="orn-cat-fonts">
+        <source>Fonts</source>
+        <translation>Skrifttype</translation>
+    </message>
+    <message id="orn-cat-libraries">
+        <source>Libraries</source>
+        <translation>Bibliotek</translation>
+    </message>
+    <message id="orn-update-available">
+        <source>Update available</source>
+        <translation>Oppdatering tilgjengelig</translation>
+    </message>
+    <message id="orn-update">
+        <source>Update</source>
+        <translation>Oppdatering</translation>
+    </message>
+    <message id="orn-changelog">
+        <source>Changelog</source>
+        <translation>Endringslogg</translation>
+    </message>
+    <message id="orn-comments-withnum">
+        <source>Comments (%0)</source>
+        <translation>Kommentarer (%0)</translation>
+    </message>
+    <message id="orn-version-repo-disabled">
+        <source>Enable the repository first</source>
+        <translation>Aktiver pakkebrønnen først</translation>
+    </message>
+    <message id="orn-search">
+        <source>Search</source>
+        <extracomment>The search menu item and the search page header text - should be a noun</extracomment>
+        <translation>Søk</translation>
+    </message>
+    <message id="orn-searchpage-placeholder-noresults">
+        <source>Nothing found</source>
+        <translation>Ingen treff</translation>
+    </message>
+    <message id="orn-searchpage-placeholder-noresults-hint">
+        <source>Try to change search keywords</source>
+        <translation>Forsøk å endre på søkeord</translation>
+    </message>
+    <message id="orn-searchfield-placeholder">
+        <source>Search</source>
+        <extracomment>The search field placeholder text - should be a verb</extracomment>
+        <translation>Søk</translation>
+    </message>
+    <message id="orn-searchpage-placeholder-default">
+        <source>Search results will be shown here</source>
+        <translation>Søkeresultater</translation>
+    </message>
+    <message id="orn-searchpage-placeholder-default-hint">
+        <source>Type some keywords in the field above</source>
+        <translation>Skriv inn søkeord i felter overfor</translation>
+    </message>
+    <message id="orn-about">
+        <source>About Storeman</source>
+        <translation>Om Storeman</translation>
+    </message>
+    <message id="orn-translations">
+        <source>Translations</source>
+        <translation>Oversettelser</translation>
+    </message>
+    <message id="orn-coordinators">
+        <source>Coordinators</source>
+        <translation>Koordinatorer</translation>
+    </message>
+    <message id="orn-translators">
+        <source>Translators</source>
+        <translation>Oversettere</translation>
+    </message>
+    <message id="orn-reviewers">
+        <source>Reviewers</source>
+        <translation>Redigenter</translation>
+    </message>
+    <message id="orn-network-error">
+        <source>A network error occurred</source>
+        <translation>En nettverkfeil oppstod</translation>
+    </message>
+    <message id="orn-pull-refresh">
+        <source>Pull down to refresh</source>
+        <translation>Dra ned for å oppdatere</translation>
+    </message>
+    <message id="orn-development">
+        <source>Development</source>
+        <translation>Utvikling</translation>
+    </message>
+    <message id="orn-developers">
+        <source>Developers</source>
+        <translation>Utviklere</translation>
+    </message>
+    <message id="orn-appicon">
+        <source>Application Icon</source>
+        <translation>Applikasjonsikon</translation>
+    </message>
+    <message id="orn-sources">
+        <source>Source Code</source>
+        <translation>Kildekode</translation>
+    </message>
+    <message id="orn-just-now">
+        <source>Just now</source>
+        <translation>Akkurat nå</translation>
+    </message>
+    <message id="orn-mins-ago" numerus="yes">
+        <source>%n minute(s) ago</source>
+        <translation>
+            <numerusform>%n minutt siden</numerusform>
+            <numerusform>%n minutter siden</numerusform>
+        </translation>
+    </message>
+    <message id="orn-hours-ago" numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation>
+            <numerusform>%n time siden</numerusform>
+            <numerusform>%n timer siden</numerusform>
+        </translation>
+    </message>
+    <message id="orn-reply-to">
+        <source>Reply to %0</source>
+        <extracomment>Active label to navigate to the original comment - should be a noun</extracomment>
+        <translation>Svar til %0</translation>
+    </message>
+    <message id="orn-categories">
+        <source>Categories</source>
+        <translation>Kategorier</translation>
+    </message>
+    <message id="orn-category-noapps">
+        <source>Currently there are no apps in this category</source>
+        <translation>Det finnes foreløpig ingen apper i denne kategorien.</translation>
+    </message>
+    <message id="orn-cat-unknown2">
+        <source>Unknown category</source>
+        <translation>Ukjent kategori</translation>
+    </message>
+    <message id="orn-comment-body">
+        <source>Your comment</source>
+        <translation>Din kommentar</translation>
+    </message>
+    <message id="orn-reply">
+        <source>Reply</source>
+        <extracomment>Menu item to reply for a comment - should be a verb</extracomment>
+        <translation>Svar</translation>
+    </message>
+    <message id="orn-edit">
+        <source>Edit</source>
+        <translation>Rediger</translation>
+    </message>
+    <message id="orn-login-menu-item">
+        <source>Log in to OpenRepos.net</source>
+        <translation>Logg på OpenRepos.net</translation>
+    </message>
+    <message id="orn-login-action">
+        <source>Log in</source>
+        <translation>Logg inn</translation>
+    </message>
+    <message id="orn-username">
+        <source>Username</source>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
+        <translation>Brukernavn</translation>
+    </message>
+    <message id="orn-login-help">
+        <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>
+        <translation>Logg inn på OpenRepos.net for å kommentere apper og svare på andres kommentarer.&lt;br /&gt;&lt;br /&gt;Storeman sender ikke passordet ditt til tredjepart.</translation>
+    </message>
+    <message id="orn-loggedin-message">
+        <source>You have successfully logged in to the OpenRepos.net</source>
+        <translation>Du er pålogget OpenRepos.net</translation>
+    </message>
+    <message id="orn-loggedout-message">
+        <source>You have logged out from the OpenRepos.net</source>
+        <translation>Du er logget ut fra OpenRepos.net</translation>
+    </message>
+    <message id="orn-login-error-title">
+        <source>Login error</source>
+        <translation>Feil ved pålogging</translation>
+    </message>
+    <message id="orn-login-error-message">
+        <source>Could not log in the OpenRepos.net - check your credentials and network connection</source>
+        <translation>Kunne ikke logge på OpenRepos.net - Kontroller brukernavn, passord og internettforbindelsen din.</translation>
+    </message>
+    <message id="orn-loggedin-menu-item">
+        <source>Logged in as %0</source>
+        <translation>Logget inn som %0</translation>
+    </message>
+    <message id="orn-logout-action">
+        <source>Log out</source>
+        <extracomment>Menu item</extracomment>
+        <translation>Logg ut</translation>
+    </message>
+    <message id="orn-logout-remorse">
+        <source>Logging out</source>
+        <extracomment>Remorse text</extracomment>
+        <translation>Logger ut</translation>
+    </message>
+    <message id="orn-comment-edit-label">
+        <source>Edit your comment</source>
+        <translation>Rediger din kommentar</translation>
+    </message>
+    <message id="orn-comment-update">
+        <source>Update</source>
+        <extracomment>Update a comment</extracomment>
+        <translation>Oppdater</translation>
+    </message>
+    <message id="orn-comment-send">
+        <source>Send</source>
+        <translation>Send</translation>
+    </message>
+    <message id="orn-authorisation-expires-summary">
+        <source>Authorisation expires</source>
+        <translation>Autorisasjon utgått </translation>
+    </message>
+    <message id="orn-authorisation-expired-summary">
+        <source>Authorisation expired</source>
+        <translation>Autorisasjon utgått</translation>
+    </message>
+    <message id="orn-reauthorise">
+        <source>Click to reauthorise</source>
+        <translation>Klikk for å reautorisere</translation>
+    </message>
+    <message id="orn-enable-all">
+        <source>Enable all</source>
+        <translation>Skru på alt</translation>
+    </message>
+    <message id="orn-disable-all">
+        <source>Disable all</source>
+        <translation>Skru av alt</translation>
+    </message>
+    <message id="orn-enabling-all">
+        <source>Enabling all</source>
+        <translation>Skrur på alt</translation>
+    </message>
+    <message id="orn-disabling-all">
+        <source>Disabling all</source>
+        <translation>Skrur av alt</translation>
+    </message>
+    <message id="orn-installed-apps">
+        <source>Installed applications</source>
+        <translation>Installerte programmer</translation>
+    </message>
+    <message id="orn-bookmarks-added">
+        <source>The app was added to bookmarks</source>
+        <translation>Program  lagt til i bokmerker</translation>
+    </message>
+    <message id="orn-bookmarks-removed">
+        <source>The app was removed from bookmarks</source>
+        <translation>Programmet ble fjernet fra bokmerker</translation>
+    </message>
+    <message id="orn-no-bookmarks">
+        <source>Your bookmarked applications will be shown here</source>
+        <translation>Dine bokmerkede programmer vil  vises her</translation>
+    </message>
+    <message id="orn-bookmarks">
+        <source>Bookmarks</source>
+        <translation>Bokmerker</translation>
+    </message>
+    <message id="orn-no-repos">
+        <source>No OpenRepos repositories have been added yet</source>
+        <translation>Det er ingen OpenRepos‑pakkebrønner lagt til ennå.</translation>
+    </message>
+    <message id="orn-add-repo-hint">
+        <source>You can add a repository from an application page</source>
+        <translation>Du kan legge til en pakkebrønn fra appens side.</translation>
+    </message>
+    <message id="orn-refresh-cache">
+        <source>Refresh cache</source>
+        <translation>Last inn cache på nytt</translation>
+    </message>
+    <message id="orn-tag-underscore">
+        <source>U</source>
+        <extracomment>Tag underscore</extracomment>
+        <translation>U</translation>
+    </message>
+    <message id="orn-tag-strong">
+        <source>B</source>
+        <extracomment>Tag strong</extracomment>
+        <translation>B</translation>
+    </message>
+    <message id="orn-tag-emphasize">
+        <source>I</source>
+        <extracomment>Tag emphasize</extracomment>
+        <translation>I</translation>
+    </message>
+    <message id="orn-updates-available-summary">
+        <source>Updates available</source>
+        <translation>Oppdateringer tilgjengelig</translation>
+    </message>
+    <message id="orn-error-depresolution">
+        <source>Nothing provides %1 needed by %2</source>
+        <extracomment>A template string for a dependecy resolution error. %1 is a dependency and %2 is a failed package.</extracomment>
+        <translation>Ingenting tilbyr %1 som kreves av %2.</translation>
+    </message>
+    <message id="orn-backups">
+        <source>Backups</source>
+        <translation>Sikkerhetskopi</translation>
+    </message>
+    <message id="orn-backup-description">
+        <source>Backup and restore repos and installed apps</source>
+        <translation>Sikkerhetskopier og gjenopprett arkiver og installerte apper</translation>
+    </message>
+    <message id="orn-create-backup">
+        <source>Create a backup</source>
+        <translation>Lag en sikkerhetskopi</translation>
+    </message>
+    <message id="orn-backup-error">
+        <source>Backup error</source>
+        <translation>Feil ved sikkerhetskopiering</translation>
+    </message>
+    <message id="orn-backup-error-directory">
+        <source>Could not create directory</source>
+        <translation>Kunne ikke opprette katalog</translation>
+    </message>
+    <message id="orn-restore-title">
+        <source>Restore from a file</source>
+        <translation>Gjenopprett fra en fil</translation>
+    </message>
+    <message id="orn-restore">
+        <source>Restore</source>
+        <translation>Gjenopprett</translation>
+    </message>
+    <message id="orn-restore-hint">
+        <source>Restore OpenRepos repositories and installed apps from the selected file. This action will not affect your current repositories and will not remove installed applications.</source>
+        <translation>Gjenopprett OpenRepos‑pakkebrønner og installerte apper fra valgt fil. Denne handlingen påvirker ikke dine nåværende depoter og vil ikke fjerne installerte apper.</translation>
+    </message>
+    <message id="orn-created">
+        <source>Created</source>
+        <translation>Opprettet</translation>
+    </message>
+    <message id="orn-total-repos">
+        <source>Total repositories</source>
+        <translation>Totalt antall pakkebrønner</translation>
+    </message>
+    <message id="orn-details">
+        <source>Details</source>
+        <translation>Detaljer</translation>
+    </message>
+    <message id="orn-backups-placeholder">
+        <source>Backups will be shown here</source>
+        <translation>Sikkerhetskopier vil vises her</translation>
+    </message>
+    <message id="orn-restoring-repos">
+        <source>Restoring repositories</source>
+        <translation>Gjenoppretter pakkebrønner</translation>
+    </message>
+    <message id="orn-refreshing-repos">
+        <source>Refreshing repositories</source>
+        <translation>Oppdaterer pakkebrønner</translation>
+    </message>
+    <message id="orn-searching-packages">
+        <source>Searching packages</source>
+        <translation>Søker etter pakker</translation>
+    </message>
+    <message id="orn-installing-repos">
+        <source>Installing packages</source>
+        <translation>Installerer pakker</translation>
+    </message>
+    <message id="orn-restoring-title">
+        <source>Restoring</source>
+        <translation >Gjenoppretter</translation>
+    </message>
+    <message id="orn-success-backup">
+        <source>Successful backup</source>
+        <translation>Sikkerhetskopiering fullført</translation>
+    </message>
+    <message id="orn-success-restore">
+        <source>Successful restore</source>
+        <translation>Gjenoppretting fullført</translation>
+    </message>
+    <message id="orn-installed-packages">
+        <source>Installed packages</source>
+        <translation>Installerte pakker</translation>
+    </message>
+    <message id="orn-login2comment">
+        <source>Login to comment</source>
+        <translation>Logg på for å kommentere</translation>
+    </message>
+    <message id="orn-backup">
+        <source>Backup</source>
+        <translation>Sikkerhetskopi</translation>
+    </message>
+    <message id="orn-backup-hint">
+        <source>&lt;h2&gt;Backup to a file&lt;/h2&gt;&lt;br /&gt;&lt;p&gt;Backup allows you to save your current OpenRepos repositories, installed applications and bookmarks and restore them later (for example after factory reset). A backup is a local file that is saved to the&lt;br /&gt;&lt;i&gt;~/Documents/Storeman&lt;/i&gt; directory.&lt;/p&gt;&lt;br /&gt;&lt;p&gt;&lt;b&gt;Attention!&lt;/b&gt; You should copy your backups manually to some safe place before performing a factory reset. It could be your SD card, external device, cloud storage or something else.&lt;/p&gt;</source>
+        <translation>&lt;h2&gt;Backup til fil&lt;/h2&gt;&lt;br /&gt;&lt;p&gt;Backup lar deg lagre dine nåværende OpenRepos‑pakkebrønner, installerte apper og bokmerker og gjenopprette dem senere (for eksempel etter tilbakestilling til fabrikkinnstillinger). En backup er en lokal fil som lagres i
+&lt;br /&gt;&lt;i&gt;~/Documents/Storeman&lt;/i&gt;-mappen.&lt;/p&gt;&lt;br /&gt;&lt;p&gt;&lt;b&gt;Obs!&lt;/b&gt; Du bør kopiere backupene manuelt til et trygt sted før du utfører tilbakestilling til fabrikkinnstillinger. Dette kan være SD‑kort, ekstern lagring, skytjeneste eller lignende.&lt;/p&gt;
+</translation>
+    </message>
+    <message id="orn-pmstate-initialising">
+        <source>Initialising</source>
+        <translation>Oppstart pågår</translation>
+    </message>
+    <message id="orn-pmstate-addingrepo">
+        <source>Adding repo %0</source>
+        <translation>Legger til pakkebrønn %0</translation>
+    </message>
+    <message id="orn-pmstate-removingrepo">
+        <source>Removing repo %0</source>
+        <translation>Fjerner pakkebrønn %0</translation>
+    </message>
+    <message id="orn-pmstate-enablingrepo">
+        <source>Enabling repo %0</source>
+        <translation>Aktiverer pakkebrønn %0</translation>
+    </message>
+    <message id="orn-pmstate-disablingrepo">
+        <source>Disabling repo %0</source>
+        <translation type="unfinished">Deaktiverer pakkebrønn %0</translation>
+    </message>
+    <message id="orn-pmstate-refreshingrepo">
+        <source>Refreshing %0</source>
+        <translation>Oppdaterer %0</translation>
+    </message>
+    <message id="orn-pmstate-installingpackage">
+        <source>Installing package %0</source>
+        <translation>Installerer pakke %0</translation>
+    </message>
+    <message id="orn-pmstate-removingpackage">
+        <source>Removing package %0</source>
+        <translation>Fjerner pakke %0</translation>
+    </message>
+    <message id="orn-pmstate-updatingpackage">
+        <source>Updating package %0</source>
+        <translation>Oppdaterer pakke %0</translation>
+    </message>
+    <message id="orn-repo-removed">
+        <source>The repository %0 was removed</source>
+        <translation>Pakkebrønn %0 ble fjernet</translation>
+    </message>
+    <message id="orn-repo-added">
+        <source>The repository %0 was added</source>
+        <translation>Pakkebrønn %0 ble lagt til</translation>
+    </message>
+    <message id="orn-repo-disabled">
+        <source>The repository %0 was disabled</source>
+        <translation>Pakkebrønn %0 ble deaktivert</translation>
+    </message>
+    <message id="orn-repo-enabled">
+        <source>The repository %0 was enabled</source>
+        <translation type="unfinished">Pakkebrønn %0 ble aktivert</translation>
+    </message>
+    <message id="orn-not-installed">
+        <source>Not installed</source>
+        <translation>Ikke innstallert</translation>
+    </message>
+    <message id="orn-installing">
+        <source>Installing</source>
+        <translation>Innstallerer</translation>
+    </message>
+    <message id="orn-unknown">
+        <source>Unknown</source>
+        <translation>Ukjent</translation>
+    </message>
+    <message id="orn-updating">
+        <source>Updating</source>
+        <translation>Oppdaterer</translation>
+    </message>
+    <message id="orn-version-available-global">
+        <source>Available in other repositories</source>
+        <translation>Tilgjengelig i andre pakkebrønner</translation>
+    </message>
+    <message id="orn-installed-apps-description">
+        <source>Only from enabled repositories</source>
+        <translation>Kun tilgjengelig fra påskrudde pakkebrønner</translation>
+    </message>
+    <message id="orn-update-all">
+        <source>Update all</source>
+        <translation>Oppdater alt</translation>
+    </message>
+    <message id="orn-no-installed-apps">
+        <source>Could not find any applications installed from OpenRepos</source>
+        <translation>Kunne ikke finne innstallerte programmer fra OpenRepos</translation>
+    </message>
+    <message id="orn-pmstate-multiple" numerus="yes">
+        <source>%n operations are in progress</source>
+        <extracomment>There are always more than 1 operations</extracomment>
+        <translation>
+            <numerusform>%n operasjon pågår</numerusform>
+            <numerusform>%n operasjoner pågår</numerusform>
+        </translation>
+    </message>
+    <message id="orn-version-available">
+        <source>Available version</source>
+        <translation>Tilgjengengelig versjon</translation>
+    </message>
+    <message id="orn-error-packagenotfound">
+        <source>Couldn&apos;t find package</source>
+        <translation>Finner ikke pakke</translation>
+    </message>
+    <message id="orn-size-installed">
+        <source>Installed size</source>
+        <translation>Installasjonens størrelse</translation>
+    </message>
+    <message id="orn-size-download-install">
+        <source>Download / install size</source>
+        <translation>Nedlasting/innstallasjonsstørrelse</translation>
+    </message>
+    <message id="orn-cat-public-transport">
+        <source>Public Transport</source>
+        <translation>Offentlig transport</translation>
+    </message>
+    <message id="orn-comments-wait">
+        <source>Wait for users&apos; feedback</source>
+        <extracomment>This will be shown to an application author</extracomment>
+        <translation>Vent på brukernes tilbakemelding</translation>
+    </message>
+    <message id="orn-comments-bethefirst">
+        <source>Be the first to comment</source>
+        <extracomment>This will be shown to a normal user</extracomment>
+        <translation>Fyr inn kommentar nummer en!</translation>
+    </message>
+    <message id="orn-comments-nocomments">
+        <source>There is nothing here yet</source>
+        <translation>Ingenting her ennå</translation>
+    </message>
+    <message id="orn-settings">
+        <source>Settings</source>
+        <translation>Innstillinger</translation>
+    </message>
+    <message id="orn-updates">
+        <source>Updates</source>
+        <translation>Oppdateringer</translation>
+    </message>
+    <message id="orn-updates-notification-switch">
+        <source>Show updates notification</source>
+        <translation>Vis oppdateringsvarsler</translation>
+    </message>
+    <message id="orn-updates-check-interval">
+        <source>Updates check interval</source>
+        <translation>Intervall for å se etter oppdateringer</translation>
+    </message>
+    <message id="orn-interval-m" numerus="yes">
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minutt</numerusform>
+            <numerusform>%n minutter</numerusform>
+        </translation>
+    </message>
+    <message id="orn-interval-h" numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n time</numerusform>
+            <numerusform>%n timer</numerusform>
+        </translation>
+    </message>
+    <message id="orn-tag-strikeout">
+        <source>S</source>
+        <extracomment>Tag strikeout</extracomment>
+        <translation>S</translation>
+    </message>
+    <message id="orn-hint-commentfield">
+        <source>Swipe to see all the tag buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="orn-dcm-user2">
+        <source>Deep Thought</source>
+        <extracomment>https://simple.wikipedia.org/wiki/42_(answer)</extracomment>
+        <translation>Tenkjar dypt</translation>
+    </message>
+    <message id="orn-dcm-user1">
+        <source>A little white mouse</source>
+        <extracomment>https://simple.wikipedia.org/wiki/42_(answer)</extracomment>
+        <translation>En liten hvit mus</translation>
+    </message>
+    <message id="orn-dcm-question">
+        <source>What is the Answer to the Ultimate Question of Life, the Universe, and Everything?</source>
+        <extracomment>https://simple.wikipedia.org/wiki/42_(answer)</extracomment>
+        <translation>Hva er svaret på det ultimate spørsmålet om livet, universet og alt?</translation>
+    </message>
+    <message id="orn-hint-commentdelegate-created">
+        <source>7.5 million years ago</source>
+        <translation>7.5 millioner år siden</translation>
+    </message>
+    <message id="orn-hint-commentdelegate">
+        <source>Tap to navigate to the replied comment</source>
+        <translation>Trykk for å gå til kommentaren det ble svart på.</translation>
+    </message>
+    <message id="orn-tags">
+        <source>Tags</source>
+        <translation>Emneknagger</translation>
+    </message>
+    <message id="orn-tag-apps">
+        <source>Tagged Applications</source>
+        <translation>Emnemerkede applikasjoner</translation>
+    </message>
+    <message id="orn-rate-app">
+        <source>Rate the application</source>
+        <translation>Vurder applikasjon</translation>
+    </message>
+    <message id="orn-vote-send">
+        <source>Your vote has been sent</source>
+        <translation>Din stemme er registrert</translation>
+    </message>
+    <message id="orn-login2rate">
+        <source>Log in to rate the application</source>
+        <translation>Logg inn for å vurdere applikasjonen</translation>
+    </message>
+    <message id="orn-hint-rating">
+        <source>Tap to rate the application</source>
+        <translation>Trykk for å vurdere applikasjonen</translation>
+    </message>
+    <message id="orn-local-rpms">
+        <source>Local RPM files</source>
+        <translation>Lokale RPM-filer</translation>
+    </message>
+    <message id="orn-delete">
+        <source>Delete</source>
+        <translation>Slett</translation>
+    </message>
+    <message id="orn-deleting">
+        <source>Deleting</source>
+        <translation>Sletter</translation>
+    </message>
+    <message id="orn-no-local-rpms">
+        <source>No local RPM files were found</source>
+        <translation>Ingen lokale RPM-filer funnet</translation>
+    </message>
+    <message id="orn-deletion-error">
+        <source>Failed to delete</source>
+        <translation>Sletting feilet</translation>
+    </message>
+    <message id="orn-remove-all">
+        <source>Remove all</source>
+        <translation>Fjern alle</translation>
+    </message>
+    <message id="orn-removing-all">
+        <source>Removing all</source>
+        <translation>Fjerner alle</translation>
+    </message>
+    <message id="orn-repo-allremoved">
+        <source>All repositories were removed</source>
+        <translation>Alle pakkebrønner ble fjernet</translation>
+    </message>
+    <message id="orn-search-on-openrepos">
+        <source>Search on OpenRepos.net</source>
+        <translation>Søk på OpenRepos.net</translation>
+    </message>
+    <message id="orn-check-for-updates-switch">
+        <source>Check for updates</source>
+        <translation>Se etter oppdateringer</translation>
+    </message>
+    <message id="orn-check-for-updates-descr">
+        <source>Updates are checked only when the Storeman is running</source>
+        <translation>Oppdateringer sjekkes bare når Storeman kjører</translation>
+    </message>
+    <message id="orn-smart-check-switch">
+        <source>Smart check</source>
+        <translation>Smart sjekk</translation>
+    </message>
+    <message id="orn-smart-check-descr">
+        <source>Use the OpenRepos.net API to determine if there are new updates</source>
+        <translation>Bruk OpenRepos.net‑APIet for å avgjøre om det finnes nye oppdateringer</translation>
+    </message>
+    <message id="orn-reload">
+        <source>Reload</source>
+        <translation>Last på nytt</translation>
+    </message>
+    <message id="orn-no-packages">
+        <source>No packages available</source>
+        <translation type="unfinished">Ingen pakker tilgjengelig</translation>
+    </message>
+    <message id="orn-error-comment-sending">
+        <source>Error sending comment</source>
+        <translation>Feil ved sending av kommentar</translation>
+    </message>
+    <message id="orn-error-comment-deletion">
+        <source>Error deleting comment</source>
+        <translation>Feil ved sletting av kommentar</translation>
+    </message>
+    <message id="orn-error-network">
+        <source>Network error</source>
+        <translation>Nettverksfeil</translation>
+    </message>
+    <message id="orn-hint-bookmark">
+        <source>Tap to bookmark the application</source>
+        <translation>Trykk for å bokmerke applikasjonen</translation>
+    </message>
+    <message id="orn-bad-appid">
+        <source>Invalid package ID %1</source>
+        <translation>Ugyldig pakke‑ID %1</translation>
+    </message>
+    <message id="orn-backup-filenameph">
+        <source>A file name for backup</source>
+        <translation>Et filnavn for sikkerhetskopi</translation>
+    </message>
+    <message id="orn-file-exists">
+        <source>File already exists</source>
+        <translation>Filen eksisterer allerede</translation>
+    </message>
+    <message id="orn-backup-items">
+        <source>What to backup</source>
+        <translation type="unfinished">Hva som skal sikkerhetskopieres</translation>
+    </message>
+    <message id="orn-backup-apps">
+        <source>Installed applications</source>
+        <translation type="unfinished">Installerte applikasjoner</translation>
+    </message>
+    <message id="orn-hint-close">
+        <source>Tap again to close the hint</source>
+        <translation type="unfinished">Trykk igjen for å lukke tipset</translation>
+    </message>
+    <message id="orn-mainpage">
+        <source>Main page</source>
+        <translation type="unfinished">Hovedside</translation>
+    </message>
+    <message id="orn-show-recent-switch">
+        <source>Show recently updated on start</source>
+        <translation>Vis nylig oppdatert ved oppstart</translation>
+    </message>
+    <message id="orn-show-recent-switch-descr">
+        <source>Switch to the page of recently updated packages on start</source>
+        <translation>Åpne siden med nylig oppdaterte pakker ved oppstart</translation>
+    </message>
+    <message id="orn-mainpage-order">
+        <source>Order items</source>
+        <translation>Bestill goppføringer</translation>
+    </message>
+    <message id="orn-reset">
+        <source>Reset</source>
+        <translation>Tilbakestill</translation>
+    </message>
+    <message id="orn-mainpage-order-description">
+        <source>Drag items to change their order</source>
+        <translation>Dra oppføringer for å endre deres rekkefølge</translation>
+    </message>
+    <message id="orn-cat-adult-content">
+        <source>Adult Content</source>
+        <translation>Kun for de voksne</translation>
+    </message>
+    <message id="orn-categories-filter">
+        <source>Categories filter</source>
+        <translation>Kategorifilter</translation>
+    </message>
+    <message id="orn-categories-filter-descr">
+        <source>Select which categories to show</source>
+        <translation>Velg hvilke kategorier som skal vises</translation>
+    </message>
+    <message id="orn-pmstate-refreshingcache">
+        <source>Refreshing of cache</source>
+        <translation>Oppfrisk mellomlagring</translation>
+    </message>
+    <message id="orn-refresh-cache-switch">
+        <source>Refresh cache after system upgrade</source>
+        <translation type="unfinished">Oppfrisk mellomlagring etter systemoppgadering</translation>
+    </message>
+    <message id="orn-refresh-cache-switch-descr">
+        <source>Force refreshing of cache of all repositories after system upgrade</source>
+        <translation type="unfinished">Tvungen oppfrisking av mellomlagring for alle pakkebrønner etter systemoppgradering</translation>
+    </message>
+    <message id="orn-save-password">
+        <source>Save password</source>
+        <translation>Lagre passord</translation>
+    </message>
+    <message id="orn-save-password-help">
+        <source>Save password to the encrypted device storage to perform automatic re-login.</source>
+        <translation>Lagre passord i enhetens krypterte lagring for automatisk pålogging. </translation>
+    </message>
+    <message id="orn-share-link">
+        <source>Share link</source>
+        <translation>Del lenke</translation>
+    </message>
+    <message id="orn-repository">
+        <source>Repository</source>
+        <translation>Pakkebrønner</translation>
+    </message>
+    <message id="orn-myrepository">
+        <source>My repository</source>
+        <translation>Mine pakkebrønner</translation>
+    </message>
+    <message id="orn-donation">
+        <source>Donation</source>
+        <translation>Donasjon</translation>
+    </message>
+    <message id="orn-cover-updates-available">
+        <source>Updates available</source>
+        <translation>Oppdateringer er tilgjengelig</translation>
+    </message>
+    <message id="orn-package-updated">
+        <source>Package %0 was successfully updated</source>
+        <translation type="unfinished">Pakke %0 ble oppdatert</translation>
+    </message>
+    <message id="orn-app-description-full">
+        <source>&lt;p&gt;OpenRepos client application for SailfishOS&lt;br /&gt;&amp;nbsp;&lt;/p&gt;&lt;p&gt;Storeman is Free Software (FLOSS), distributed under the terms of the &lt;a href=&apos;%1&apos;&gt;MIT&amp;nbsp;license&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Issues shall be reported preferably at GitHub or alternatively at OpenRepos (use the buttons below).&lt;/p&gt;</source>
+        <extracomment>Avoid to translate the acronym FLOSS (Free, Libre, Open Source Software).</extracomment>
+        <translation>&lt;p&gt;OpenRepos‑klientapplikasjon for SailfishOSOS&lt;br /&gt;&amp;nbsp;&lt;/p&gt;&lt;p&gt;Storeman er fri programvare (FLOSS), distribuert under vilkårene i &lt;a href=&apos;%1&apos;&gt;MIT&amp;nbsp;lisensen&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Feil bør rapporteres helst på GitHub eller alternativt på OpenRepos (bruk knappene nedenfor).&lt;/p&gt;</translation>
+    </message>
+    <message id="orn-show-details">
+        <source>Show details</source>
+        <translation>Vis detaljer</translation>
+    </message>
+    <message id="orn-unused-repos-found">
+        <source>Unused repositories found</source>
+        <translation>Ubrukte pakkebrønner funnet</translation>
+    </message>
+    <message id="orn-no-unused-repos">
+        <source>Unused repositories not found</source>
+        <translation>Ingen ubrukte pakkebrønner funnet</translation>
+    </message>
+    <message id="orn-search-unused-repos">
+        <source>Search for unused</source>
+        <translation>Søk etter ubrukte</translation>
+    </message>
+    <message id="orn-unused-repos-switch">
+        <source>Search for unused repositories</source>
+        <translation>Søk etter ubrukte pakkebrønner</translation>
+    </message>
+    <message id="orn-unused-repos-switch-descr">
+        <source>Search for unused repositories after removing packages.</source>
+        <translation>Søk etter ubrukte pakkebrønner etter fjerning av pakker.</translation>
+    </message>
+    <message id="orn-unused-repos">
+        <source>Unused repositories</source>
+        <translation>Ubrukte pakkebrønner</translation>
+    </message>
+    <message id="orn-unused-repos-text">
+        <source>&lt;p&gt;There are no installed packages for the next repositories.&lt;/p&gt;&lt;p&gt;Do you want to remove them now?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Det finnes ingen installerte pakker for disse pakkebrønnene.&lt;/p&gt;&lt;p&gt;Vil du fjerne dem nå?&lt;/p&gt;</translation>
+    </message>
+    <message id="orn-updates-check-interval-minimum">
+        <source>At least 10 minutes</source>
+        <translation>Minst 10 minutter</translation>
+    </message>
+    <message id="orn-check-for-self-updates-switch">
+        <source>Check for self-updates</source>
+        <translation>Se etter oppdateringer for programmet</translation>
+    </message>
+    <message id="orn-check-for-self-updates-descr">
+        <source>Enable the Storeman OBS repository to check for Storeman updates</source>
+        <translation>Aktiver Storeman OBS-pakkebrønnen for å se etter oppdateringer av Storeman</translation>
+    </message>
+    <message id="orn-storeman-repo-name">
+        <source>Storeman OBS Repository</source>
+        <translation>Storeman OBS-pakkebrønn</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Completed the work started by others to get a full translation of Storeman in Norwegian bokmål.

Filename is changed from harbour-storeman-no to nb to reflect that this is Norwegian bokmål and not nynorsk (the other official language in Norway).